### PR TITLE
 ci: integration test against bitcoin/bitcoin#35182 @ ddefe4263b 

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: pull bitcoind from docker image
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
-          docker pull pinheadmz/bitcoin:pr35182-ddefe4263b
-          cid=$(docker create pinheadmz/bitcoin:pr35182-ddefe4263b)
+          docker pull pinheadmz/bitcoin:pr35182-bb0e968
+          cid=$(docker create pinheadmz/bitcoin:pr35182-bb0e968)
           docker cp $cid:/opt/bin/bitcoind   $GITHUB_WORKSPACE/bin/bitcoind
           docker cp $cid:/opt/bin/bitcoin-cli $GITHUB_WORKSPACE/bin/bitcoin-cli
           # bitcoin-cli links capnp 1.1.0 (PR #35182 IPC); not in Ubuntu repos.

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: pull bitcoind from docker image
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
-          docker pull pinheadmz/bitcoin:pr35182-bb0e968
-          cid=$(docker create pinheadmz/bitcoin:pr35182-bb0e968)
+          docker pull pinheadmz/bitcoin:pr35182
+          cid=$(docker create pinheadmz/bitcoin:pr35182)
           docker cp $cid:/opt/bin/bitcoind   $GITHUB_WORKSPACE/bin/bitcoind
           docker cp $cid:/opt/bin/bitcoin-cli $GITHUB_WORKSPACE/bin/bitcoin-cli
           # bitcoin-cli links capnp 1.1.0 (PR #35182 IPC); not in Ubuntu repos.

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -6,142 +6,70 @@ on:
       - master
   pull_request:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-
 jobs:
-  ##################
-  # Jobs with matrix
-  ##################
-  unit:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18, 'lts/*']
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run unit
+  # Integration test against bitcoin/bitcoin#35182 (HTTP server rewrite)
+  # at commit ddefe4263b42aa050a4bd55c073e1640f06e7332.
   integration:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 'lts/*']
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-    services:
-      regtest:
-        image: junderw/bitcoinjs-regtest-server@sha256:5b69cf95d9edf6d5b3a00504665d6b3c382a6aa3728fe8ce897974c519061463
-        ports:
-          - 8080:8080
+        node-version: [18, 20]
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
           cache: 'npm'
-      - run: npm ci
-      - run: APIURL=http://127.0.0.1:8080/1 npm run integration
-
-
-
-  #####################
-  # Jobs without matrix
-  #####################
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run coverage
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run format:ci
-  gitdiff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run gitdiff:ci
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run lint
-  lint-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run lint:tests
-
-  build-doc:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run doc
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          name: github-pages
-          path: ./docs
-
-  deploy-doc:
-    if: github.ref == 'refs/heads/master'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build-doc
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: install
+        run: npm ci
+      - name: pull bitcoind from docker image
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          docker pull pinheadmz/bitcoin:pr35182-ddefe4263b
+          cid=$(docker create pinheadmz/bitcoin:pr35182-ddefe4263b)
+          docker cp $cid:/opt/bin/bitcoind   $GITHUB_WORKSPACE/bin/bitcoind
+          docker cp $cid:/opt/bin/bitcoin-cli $GITHUB_WORKSPACE/bin/bitcoin-cli
+          # bitcoin-cli links capnp 1.1.0 (PR #35182 IPC); not in Ubuntu repos.
+          sudo mkdir -p /opt/bitcoin-pr35182-lib
+          for lib in libcapnp-1.1.0.so libcapnp-rpc-1.1.0.so libkj-1.1.0.so libkj-async-1.1.0.so; do
+            sudo docker cp $cid:/usr/lib/x86_64-linux-gnu/$lib /opt/bitcoin-pr35182-lib/
+          done
+          echo /opt/bitcoin-pr35182-lib | sudo tee /etc/ld.so.conf.d/bitcoin-pr35182.conf
+          sudo ldconfig
+          docker rm $cid
+          chmod +x $GITHUB_WORKSPACE/bin/*
+          sudo apt-get update -y
+          sudo apt-get install -y libevent-dev libboost-dev libzmq3-dev libsqlite3-dev
+          $GITHUB_WORKSPACE/bin/bitcoind -version
+      - name: start bitcoind regtest
+        run: |
+          $GITHUB_WORKSPACE/bin/bitcoind -regtest -txindex \
+            -zmqpubhashtx=tcp://127.0.0.1:30001 \
+            -zmqpubhashblock=tcp://127.0.0.1:30001 \
+            -rpcworkqueue=32 -daemon
+          $GITHUB_WORKSPACE/bin/bitcoin-cli -regtest -rpcwait createwallet ci
+          $GITHUB_WORKSPACE/bin/bitcoin-cli -regtest -rpcwait -generate 432
+      - name: start regtest-server
+        run: |
+          git clone https://github.com/bitcoinjs/regtest-server
+          cd regtest-server
+          npm install
+          mkdir ~/regtest-data
+          echo "satoshi" > ~/regtest-data/KEYS
+          export RPCCOOKIE=~/.bitcoin/regtest/.cookie
+          export KEYDB=~/regtest-data/KEYS
+          export INDEXDB=~/regtest-data/db
+          export ZMQ=tcp://127.0.0.1:30001
+          export RPCCONCURRENT=32
+          export RPC=http://localhost:18443
+          export PORT=8080
+          node index.js &
+          sleep 5
+      - name: test
+        run: |
+          export APIPASS=satoshi
+          export APIURL=http://127.0.0.1:8080/1
+          npm run integration

--- a/test/integration/transactions.spec.ts
+++ b/test/integration/transactions.spec.ts
@@ -189,7 +189,7 @@ describe('bitcoinjs-lib (transactions with psbt)', () => {
       .addInput(inputData1)
       .addOutput({
         script: embed.output!,
-        value: 1000n,
+        value: 0n,
       })
       .addOutput({
         address: regtestUtils.RANDOM_ADDRESS,


### PR DESCRIPTION
Replace the regtest-server docker service in main_ci.yml with an
in-job bitcoind from pinheadmz/bitcoin:pr35182-ddefe4263b: pull the
docker image, copy /opt/bin/bitcoind + bitcoin-cli out, start regtest
+ wallet + 432-block premine, then run bitcoinjs/regtest-server on top
of it pointing at the rpc cookie. The integration suite then runs
against http://127.0.0.1:8080/1 like before.

CI matrix trimmed to node-version 18 and 20; lint/format/docs/coverage
jobs dropped on this integration branch.